### PR TITLE
Improve exception handling and add configurable API timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ unifi_wifi:
     password: NotARealPassword
     site: default
     scan_interval: 300
+    timeout: 20
     unifi_os: true
     verify_ssl: false
+    force_provision: false
     managed_aps:
       - name: udm
         mac: !secret unifi_udm_mac
@@ -56,7 +58,10 @@ unifi_wifi:
 
 - **scan_interval** <sup><sub>string</sub></sup> (optional, default: 600) &nbsp; How often, in seconds, Home Assistant should poll the controller.
 
+  > [!NOTE] 
   > *If you change a password through the controller UI multiple times before ```scan_interval``` triggers an update, only the last change will be detected.*
+
+- **timeout** <sup><sub>string</sub></sup> (optional, default: 10) &nbsp; How many seconds an update request to the controller will wait before timing out.
 
 - **unifi_os** <sup><sub>boolean</sub></sup> (optional, default: true) &nbsp; The *truthiness* of this variable is used to determine API url paths. Set to true (or omit) if your controller is running on UniFi OS; otherwise set to false. Only use this if you're running controller software separately (i.e. Docker, Raspberry Pi, etc).
 
@@ -143,7 +148,7 @@ unifi_wifi:
       enable: false
   ```
 
-  > [!WARNING]
+  > [!IMPORTANT]
   > *Disabling a PPSK network will disable its SSID which will disable all other associated PPSK networks; the same applies when enabling.*
 
 [^1]: https://my.home-assistant.io/create-link/

--- a/custom_components/unifi_wifi/__init__.py
+++ b/custom_components/unifi_wifi/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
     CONF_USERNAME,
     CONF_VERIFY_SSL
 )
@@ -52,6 +53,7 @@ _SITE_SCHEMA = vol.Schema({
     vol.Optional(CONF_SITE, default='default'): cv.string,
     vol.Optional(CONF_PORT, default=443): cv.port,
     vol.Optional(CONF_SCAN_INTERVAL, default=600): cv.time_period,
+    vol.Optional(CONF_TIMEOUT, default=10): cv.positive_int,
     vol.Optional(CONF_UNIFI_OS, default=True): cv.boolean,
     vol.Optional(CONF_VERIFY_SSL, default=False): cv.boolean,
     vol.Optional(CONF_FORCE_PROVISION, default=False): cv.boolean,

--- a/custom_components/unifi_wifi/coordinator.py
+++ b/custom_components/unifi_wifi/coordinator.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
+    CONF_TIMEOUT,
     CONF_VERIFY_SSL,
     CONF_USERNAME,
     STATE_UNAVAILABLE,
@@ -99,6 +100,7 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         self._password = conf[CONF_PASSWORD]
         self._force = conf[CONF_FORCE_PROVISION]
         self._aps = conf[CONF_MANAGED_APS]
+        self._timeout = conf[CONF_TIMEOUT]
         self._unifi_os = conf[CONF_UNIFI_OS]
         if self._unifi_os:
             self._login_prefix = '/api/auth'
@@ -111,7 +113,7 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with asyncio.timeout(10):
+            async with asyncio.timeout(self._timeout):
                 return await self._update_info()
         except ApiAuthError as err:
             # Raising ConfigEntryAuthFailed will cancel future updates

--- a/custom_components/unifi_wifi/coordinator.py
+++ b/custom_components/unifi_wifi/coordinator.py
@@ -11,11 +11,8 @@
 
 from __future__ import annotations
 
-# import logging, mimetypes, os, collections, aiohttp, async_timeout, qrcode, io
-# are mimetypes and os necessary?
-import logging, collections, aiohttp, async_timeout, qrcode, io
+import logging, collections, aiohttp, asyncio, qrcode, io
 
-from datetime import timedelta
 from homeassistant.components.image import ImageEntity
 from homeassistant.const import (
     CONF_ENABLED,
@@ -31,7 +28,7 @@ from homeassistant.const import (
     STATE_UNKNOWN
 )
 from homeassistant.core import callback, HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, PlatformNotReady, IntegrationError
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
@@ -69,6 +66,14 @@ DEBUG = False
 _LOGGER = logging.getLogger(__name__)
 
 
+class ApiAuthError(IntegrationError):
+    """Raised when a status code of 401 HTTPUnauthorized is received."""
+
+
+class ApiError(IntegrationError):
+    """Raised when a status code of 500 or greater is received."""
+
+
 class UnifiWifiCoordinator(DataUpdateCoordinator):
     """Representation of a Unifi Wifi coordinator"""
 
@@ -79,7 +84,6 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
             # Name of the data. For logging purposes.
             name=f"{conf[CONF_NAME]} UniFi coordinator",
             # Polling interval. Will only be polled if there are subscribers.
-            # update_interval=timedelta(seconds=30),
             update_interval=conf[CONF_SCAN_INTERVAL],
         )
 
@@ -107,13 +111,14 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
-            async with async_timeout.timeout(10):
+            async with asyncio.timeout(10):
                 return await self._update_info()
-        except ConnectionError as err:
-            # # Raising ConfigEntryAuthFailed will cancel future updates
-            # # and start a config flow with SOURCE_REAUTH (async_step_reauth)
-            # raise ConfigEntryAuthFailed from err
-            raise PlatformNotReady(f"Error communicating with API: {err}")
+        except ApiAuthError as err:
+            # Raising ConfigEntryAuthFailed will cancel future updates
+            # and start a config flow with SOURCE_REAUTH (async_step_reauth)
+            raise ConfigEntryAuthFailed from err
+        except ApiError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     async def _request(self, session: aiohttp.ClientSession, method: str, path: str, **kwargs) -> aiohttp.ClientResponse:
         """Make a request."""
@@ -127,24 +132,31 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         resp = await session.request(method, fullpath, **kwargs, headers=headers)
 
         if DEBUG:
-            _LOGGER.debug("_request path %s", fullpath)
-            _LOGGER.debug("_request kwargs %s", kwargs)
-            _LOGGER.debug("_request headers %s", headers)
+            _LOGGER.debug("_request path %s: (status %s)", fullpath, resp.status)
+            _LOGGER.debug("_request kwargs: %s", kwargs)
+            _LOGGER.debug("_request headers: %s", headers)
             _LOGGER.debug("%s response: %s", path, await resp.json())
             _LOGGER.debug("%s response cookies: %s", path, resp.cookies)
             _LOGGER.debug("%s response headers: %s", path, resp.headers)
+
+        status = resp.status
+        if status == 401:
+            raise ApiAuthError(f"{await resp.json()}")
+        if status >= 500:
+            raise ApiError(f"{await resp.json()}")
+
+        if not resp.ok: # not a 2xx status code
+            resp.raise_for_status()
 
         return resp
 
     async def _login(self, session: aiohttp.ClientSession):
         """log into a UniFi controller."""
         payload = {'username': self._user, 'password': self._password}
-        headers = {'Content-Type': 'application/json'}
+        headers = {'Content-Type': 'application/json', 'accept': 'application/json'}
         kwargs = {'json': payload, 'headers': headers}
         path = f"{self._login_prefix}/login"
-        resp = await self._request(session, 'post', path, **kwargs)
-
-        return resp
+        return await self._request(session, 'post', path, **kwargs)
 
     async def _logout(self, session: aiohttp.ClientSession, csrf_token: str) -> None:
         """log out of a UniFi controller."""

--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -2,6 +2,7 @@ unifi_wifi:
   - name: myhouse
     site: default
     scan_interval: 300
+    timeout: 20
     host: !secret unifi_host
     port: 443
     username: !secret unifi_username


### PR DESCRIPTION
Add logic to raise exceptions when the HTTP status code is 400 or greater. This is partly a hotfix for a 'quirk' in the UDM 3.2.7 firmware where occasionally the API would return ```{'error': {'code': 500, 'message': 'Internal Server Error'}}```.

Previously, this error was passed along as expected data but would cause an error when attempting to extract the X-CSRF token. This behavior seems to occur regularly, however the hard-coded 10 second timeout in  ```async_timeout()```, now ```asyncio.timeout()```, would typically prevent the API from being able to send this response.

Additionally, an option to change the API timeout, in seconds, has been added.