### PR TITLE
Change re-provisioning logic

### DIFF
--- a/custom_components/unifi_wifi/coordinator.py
+++ b/custom_components/unifi_wifi/coordinator.py
@@ -62,7 +62,7 @@ from .const import (
     UNIFI_CSRF_TOKEN
 )
 
-DEBUG = False
+EXTRA_DEBUG = False
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -133,8 +133,9 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         fullpath = f"https://{self._host}:{self._port}{path}"
         resp = await session.request(method, fullpath, **kwargs, headers=headers)
 
-        if DEBUG:
-            _LOGGER.debug("_request path %s: (status %s)", fullpath, resp.status)
+        _LOGGER.debug("_request path %s: (status %s)", fullpath, resp.status)
+
+        if EXTRA_DEBUG:
             _LOGGER.debug("_request kwargs: %s", kwargs)
             _LOGGER.debug("_request headers: %s", headers)
             _LOGGER.debug("%s response: %s", path, await resp.json())

--- a/custom_components/unifi_wifi/services.py
+++ b/custom_components/unifi_wifi/services.py
@@ -271,7 +271,7 @@ async def register_services(hass: HomeAssistant, coordinators: List[UnifiWifiCoo
                 except:
                     payload = {UNIFI_PASSPHRASE: y[CONF_PASSWORD]}
                 if DEBUG: _LOGGER.debug("ssid %s with payload %s", y[CONF_SSID], payload)
-                await coordinator.set_wlanconf(y[CONF_SSID], payload)
+                await coordinator.set_wlanconf(y[CONF_SSID], payload, False)
 
 
     async def custom_password_service(call: ServiceCall):
@@ -330,7 +330,7 @@ async def register_services(hass: HomeAssistant, coordinators: List[UnifiWifiCoo
                 # boolean python values (uppercase) need to be json serialized (lowercase)
                 payload = json.dumps({CONF_ENABLED: y[CONF_ENABLED]})
                 if DEBUG: _LOGGER.debug("ssid %s with payload %s", y[CONF_SSID], payload)
-                await coordinator.set_wlanconf(y[CONF_SSID], payload)
+                await coordinator.set_wlanconf(y[CONF_SSID], payload, False)
 
 
     hass.helpers.service.async_register_admin_service(


### PR DESCRIPTION
Some service calls (i.e. unifi_wifi.enable_lan) need to force a re-provisioning of access points for changes to be fully applied. Before, the YAML config needed to include ```force_provision: true```. The immediate downside is even simple password changes would cause a re-provision to occur. This PR allows individual service calls the ability to force a re-provision while allowing the user to maintain ```force_provision: false``` in YAML. This option is not accessible through the UI, only in services.py