### PR TITLE
fix enable_wlan service

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ unifi_wifi:
 
   Change SSID password on UniFi network to a randomly generated string
   - char --> 24-character alphanumeric string
-  - word --> 4-word string, generated from the [EFF large wordlist](https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt) [^4]. This wordfile is located in ```custom_components/unfi_wifi```
+  - word --> 4-word string, generated from the [EFF large wordlist](https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt) [^2]. This wordfile is located in ```custom_components/unfi_wifi```
   - xkcd --> 4-word string, generated using [xkcdpass](https://pypi.org/project/xkcdpass). By default, xkcdpass only has access to the same wordfile as ```word```. The benefit of xkcdpass is having control over the length of words chosen.
 
   ```yaml
@@ -135,7 +135,7 @@ unifi_wifi:
   | target | no | image entity of wireless network whose password you want to change. Multiple entities are possible using the ```entity_id``` key. |
   | enabled | no | enabled = true, disabled = false |
 
-  Enable (or disable) a specific SSID on a UniFi network controller
+  Enable (or disable) a specific SSID on a UniFi network controller. *For this change to take effect properly, all (managed) access points will be re-provisioned regardless of the value of ```force_provision```.*
 
   ```yaml
     # example
@@ -152,6 +152,4 @@ unifi_wifi:
   > *Disabling a PPSK network will disable its SSID which will disable all other associated PPSK networks; the same applies when enabling.*
 
 [^1]: https://my.home-assistant.io/create-link/
-[^2]: https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp
-[^3]: https://regexr.com/7c1b0
-[^4]: https://www.eff.org/dice
+[^2]: https://www.eff.org/dice

--- a/custom_components/unifi_wifi/image.py
+++ b/custom_components/unifi_wifi/image.py
@@ -44,6 +44,7 @@ from .coordinator import UnifiWifiCoordinator
 
 EXTRA_DEBUG = False
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -261,6 +262,8 @@ class UnifiWifiImage(CoordinatorEntity, ImageEntity, RestoreEntity):
             self._attributes[UNIFI_ID] = self.coordinator.wlanconf[idssid][UNIFI_ID]
 
             _LOGGER.debug("SSID %s on coordinator %s is now %s", self._attributes[CONF_SSID], self._attributes[CONF_COORDINATOR], 'enabled' if bool(self._attributes[CONF_ENABLED]) else 'disabled')
+
+            self.async_write_ha_state()
 
         if password_change:
             self._attributes[CONF_PASSWORD] = new_password

--- a/custom_components/unifi_wifi/services.py
+++ b/custom_components/unifi_wifi/services.py
@@ -47,6 +47,7 @@ from . import password as pw
 
 EXTRA_DEBUG = False
 
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -328,9 +329,11 @@ async def register_services(hass: HomeAssistant, coordinators: List[UnifiWifiCoo
             coordinator = coordinators[idcoord]
             for y in x[CONF_DATA]:
                 # boolean python values (uppercase) need to be json serialized (lowercase)
-                payload = json.dumps({CONF_ENABLED: y[CONF_ENABLED]})
+                # payload = json.dumps({CONF_ENABLED: y[CONF_ENABLED]})
+                # apparently, the capitalized boolean value is actually REQUIRED ... weird
+                payload ={CONF_ENABLED: y[CONF_ENABLED]}
                 if EXTRA_DEBUG: _LOGGER.debug("ssid %s with payload %s", y[CONF_SSID], payload)
-                await coordinator.set_wlanconf(y[CONF_SSID], payload, False)
+                await coordinator.set_wlanconf(y[CONF_SSID], payload, True)
 
 
     hass.helpers.service.async_register_admin_service(


### PR DESCRIPTION
Previously, the boolean state value of a WLAN was being changed to lowercase before sending it to the controller. This was being silently rejected by the controller. Now, this boolean will remain capitalized. Additionally, this service will now force a re-provision.