### PR TITLE
initial support for custom colors and choosing preshared keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,17 @@ unifi_wifi:
       - name: u6lite
         mac: !secret unifi_u6l_mac
     monitored_ssids:
-      - name: my-wireless-network
+      - name: LAN
+        fill_color: '#aaaaaa' # omit for default value #000000
+        back_color: '#bbbbbb' # omit for default value #ffffff
+      - name: my-ppsk-network
+        preshared_keys:
+          - name: Guest
+            fill_color: '#cccccc'
+            back_color: '#dddddd'
+          - name: IoT
+            fill_color: '#eeeeee'
+          - name: NoT
 ```
 
 ### Configuration Variables
@@ -69,9 +79,9 @@ unifi_wifi:
 
 - **managed_aps** <sup><sub>list</sub></sup> (optional) &nbsp; List of access points to force provision after changing a SSID password. The ```name``` key is user generated and does not affect anything other than log output. The ```mac``` key must be the MAC address of the access point which can be found in the contorller UI. Both ```name``` and ```mac``` keys are required.
 
-- **monitored_ssids** <sup><sub>list</sub></sup> (optional) &nbsp; Using the ```name``` key, any wireless networks included here will have image entities created. The image uses the [Image](https://www.home-assistant.io/integrations/image) native integration released in [2023.7](https://www.home-assistant.io/blog/2023/07/05/release-20237/#image-entities) to display a QR code for joining the wireless network and has attributes including enabled state, controller name, site name, ssid name, network id, password, ppsk status, QR code generation text, and timestamp of last update.
+- **monitored_ssids** <sup><sub>list</sub></sup> (optional) &nbsp; Using the ```name``` key, any wireless networks included here will have image entities created. The image uses the [Image](https://www.home-assistant.io/integrations/image) native integration released in [2023.7](https://www.home-assistant.io/blog/2023/07/05/release-20237/#image-entities) to display a QR code for joining the wireless network and has attributes including enabled state, controller name, site name, ssid name, network id, password, ppsk status, QR code generation text, and timestamp of last update. The color of the QR code can be changed using the ```fill_color``` (default is #000000 aka black) and ```back_color``` (default is #ffffff AKA white) keys where ```back_color``` is the background color. These colors must be provided as hex values.
   
-  > *Currently, when adding a PPSK-enabled SSID, images for each PPSK-connected VLAN will be created. The ability to specify which VLAN PPSK(s) to monitor is not yet supported.*
+  > *When adding a PPSK-enabled SSID, images for each PPSK-connected VLAN will be created by default. These will inherit the colors of their parent SSID. If you want to create images only for specific PPSK-enabled VLANs, then use the ```preshared_keys``` key to create a list of networks using the ```name``` key. Each entry may optionally have customized colors using the ```fill_color``` and ```back_color``` keys.*
 
 ## Services
 
@@ -95,7 +105,7 @@ unifi_wifi:
   ```
   
   > [!NOTE]
-  > *If you try setting private preshared keys on the same SSID to the same password, only the first VLAN (alphabetically) will have its password changed.*
+  > *If you try setting private preshared keys on the same SSID to the same password, ~~only the first VLAN (alphabetically) will have its password changed~~ the integration will create an error warning the user duplicate passwords are not allowed on the same SSID.*
 
 ### ```unifi_wifi.random_password```
   | Service data attribute | Optional | Description |
@@ -125,7 +135,7 @@ unifi_wifi:
   ```
 
   > [!NOTE]
-  > *Randomizing multiple private preshared keys on the same SSID will result in multiple random passwords generated. Which is the way it should be anyways ...*
+  > *Randomizing multiple private preshared keys on the same SSID will result in multiple random passwords generated. In the unlikely event multiple randomly created passwords are identical, the integration will create an error and not complete the service call.*
 
 ### ```unifi_wifi.enable_wlan```
   | Service data attribute | Optional | Description |

--- a/custom_components/unifi_wifi/__init__.py
+++ b/custom_components/unifi_wifi/__init__.py
@@ -21,10 +21,12 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 from .const import (
     DOMAIN,
+    CONF_BACK_COLOR,
+    CONF_FILL_COLOR,
     CONF_FORCE_PROVISION,
     CONF_MANAGED_APS,
     CONF_MONITORED_SSIDS,
-    CONF_PPSK,
+    CONF_PRESHARED_KEYS,
     CONF_SITE,
     CONF_SSID,
     CONF_UNIFI_OS
@@ -35,6 +37,12 @@ from .coordinator import UnifiWifiCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+_PPSK_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_FILL_COLOR, default='#000000'): cv.color_hex,
+    vol.Optional(CONF_BACK_COLOR, default='#ffffff'): cv.color_hex
+})
+
 _AP_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
     vol.Required(CONF_MAC): cv.string
@@ -42,7 +50,11 @@ _AP_SCHEMA = vol.Schema({
 
 _SSID_SCHEMA = vol.Schema({
     vol.Required(CONF_NAME): cv.string,
-    # provide a way to list specific ppsk vlans
+    vol.Optional(CONF_PRESHARED_KEYS, default=[]): vol.All (
+        cv.ensure_list, [_PPSK_SCHEMA]
+    ),
+    vol.Optional(CONF_FILL_COLOR, default='#000000'): cv.color_hex,
+    vol.Optional(CONF_BACK_COLOR, default='#ffffff'): cv.color_hex
 })
 
 _SITE_SCHEMA = vol.Schema({

--- a/custom_components/unifi_wifi/const.py
+++ b/custom_components/unifi_wifi/const.py
@@ -1,25 +1,30 @@
 """Constants for the Unifi Wifi integration."""
 
 DOMAIN = 'unifi_wifi'
-CONF_MANAGED_APS = 'managed_aps'
+
+CONF_BACK_COLOR = 'back_color'
 CONF_CHAR_COUNT = 'char_count'
 CONF_COORDINATOR = 'coordinator'
 CONF_DATA = 'data'
 CONF_DELIMITER = 'delimiter'
 CONF_DELIMITER_TYPES = ['dash','space','underscore','none']
+CONF_FILL_COLOR = 'fill_color'
 CONF_FORCE_PROVISION = 'force_provision'
+CONF_MANAGED_APS = 'managed_aps'
 CONF_MAX_LENGTH = 'max_length'
 CONF_METHOD_TYPES = ['xkcd','word','char']
 CONF_MIN_LENGTH = 'min_length'
 CONF_MONITORED_SSIDS = 'monitored_ssids'
 CONF_NETWORK_NAME = 'network_name'
 CONF_PPSK = 'ppsk'
+CONF_PRESHARED_KEYS = 'preshared_keys'
 CONF_QRTEXT = 'qr_text'
 CONF_SITE = 'site'
 CONF_SSID = 'ssid'
 CONF_TIMESTAMP = 'timestamp'
 CONF_UNIFI_OS = 'unifi_os'
 CONF_WORD_COUNT = 'word_count'
+
 # Some of the below values are duplicates of homeassistant.const values
 # This is done to allow for changes in UniFi API keys
 UNIFI_ID = '_id'

--- a/custom_components/unifi_wifi/manifest.json
+++ b/custom_components/unifi_wifi/manifest.json
@@ -9,6 +9,6 @@
     "integration_type": "hub",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/rootnegativ1/unifi-wifi/issues",
-    "requirements": ["xkcdpass>=1.19.8","qrcode>=7.4.2"],
+    "requirements": ["xkcdpass>=1.19.8","qrcode[pil]>=7.4.2"],
     "version": "2.0.4"
 }

--- a/example_configuration.yaml
+++ b/example_configuration.yaml
@@ -17,6 +17,14 @@ unifi_wifi:
         mac: !secret unifi_u6l_mac
     monitored_ssids:
       - name: Guest
+        fill_color: '#490361'
+        back_color: '#9cedf0'
+      - name: StuffandThings
+        preshared_keys:
+          - name: NoT
+            fill_color: '#a84032'
+            back_color: '#bfb7b6'
+          - name: IoT
 
 
 # logger:
@@ -45,8 +53,6 @@ template:
       press:
         - service: unifi_wifi.random_password
           data:
-            #name: myhouse
-            #ssid: Guest
             target: image.myhouse_guest_wifi
             method: word
 
@@ -55,8 +61,6 @@ template:
       press:
         - service: unifi_wifi.custom_password
           data:
-            #name: myhouse
-            #ssid: Guest
             target: image.myhouse_guest_wifi
             password: "SOME-KNOWN-DEFAULT"
 
@@ -65,8 +69,6 @@ template:
       press:
         - service: unifi_wifi.custom_password
           data:
-            #name: myhouse
-            #ssid: Guest
             target: image.myhouse_guest_wifi
             password: "{{states('input_text.guest_wifi')}}"
         - service: input_text.set_value

--- a/example_requests.json
+++ b/example_requests.json
@@ -1,0 +1,50 @@
+[
+  {
+    "coordinator": "C1",
+    "data": [
+      {
+        "ssid": "C1S1",
+        "password": "C1S1P1"
+      },
+      {
+        "ssid": "C1S2",
+        "private_preshared_keys": [
+          {
+            "networkconf_id": "C1S2N1",
+            "password": "C1S2N1P1"
+          },
+          {
+            "networkconf_id": "C1S2N2",
+            "password": "C1S2N2P2"
+          },
+          {
+            "networkconf_id": "C1S2N3",
+            "password": "C1S2N3P3"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "coordinator": "C2",
+    "data": [
+      {
+        "ssid": "C2S1",
+        "password": "C2S1P1"
+      },
+      {
+        "ssid": "C2SS2",
+        "private_preshared_keys": [
+          {
+            "networkconf_id": "C2SS2N1",
+            "password": "C2SS2N1P1"
+          },
+          {
+            "networkconf_id": "C2SS2N2",
+            "password": "C2SS2N2P2"
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
QR codes can now have custom colors using hex colors using ```back_color``` and ```fill_color``` keys under each ssid provided under ```monitored_ssids```. Also, users can now provide a list of preshared keys to display as QR codes using the ```preshared_keys``` key under any ssid with these enabled.