### PR TITLE
fix deprecated hass.helpers

### DIFF
--- a/custom_components/unifi_wifi/services.py
+++ b/custom_components/unifi_wifi/services.py
@@ -19,6 +19,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, Context
 from homeassistant.exceptions import InvalidEntityFormatError, ServiceValidationError, Unauthorized, IntegrationError
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers import service
+from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 from typing import List # required for type hinting (function annotation) using List
 from .const import (
@@ -376,28 +377,32 @@ async def register_services(hass: HomeAssistant, coordinators: List[UnifiWifiCoo
         await _ssid_requests(states, CONF_HIDE_SSID, hide_ssid, True)
 
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_CUSTOM_PASSWORD,
         custom_password_service,
         schema=SERVICE_CUSTOM_PASSWORD_SCHEMA
     )
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_RANDOM_PASSWORD,
         random_password_service,
         schema=SERVICE_RANDOM_PASSWORD_SCHEMA
     )
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_ENABLE_WLAN,
         enable_wlan_service,
         schema=SERVICE_ENABLE_WLAN_SCHEMA
     )
 
-    hass.helpers.service.async_register_admin_service(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         SERVICE_HIDE_SSID,
         hide_ssid_service,


### PR DESCRIPTION
The use of ```hass.helpers``` has been [deprecated](https://developers.home-assistant.io/blog/2024/03/30/deprecate-hass-helpers) as of Home Assistant 2024.5. This fixes the log warning:

```
WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'unifi_wifi' accesses hass.helpers.service. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from service directly at custom_components/unifi_wifi/services.py, line 379: hass.helpers.service.async_register_admin_service(, please create a bug report at https://github.com/rootnegativ1/unifi-wifi/issues
```