### PR TITLE
Automatically update wpa3 only flag in QR code

### DIFF
--- a/custom_components/unifi_wifi/const.py
+++ b/custom_components/unifi_wifi/const.py
@@ -26,11 +26,11 @@ CONF_SSID = 'ssid'
 CONF_TIMESTAMP = 'timestamp'
 CONF_UNIFI_OS = 'unifi_os'
 CONF_WORD_COUNT = 'word_count'
-CONF_WPA3_SUPPORT = 'wpa3_support'
-CONF_WPA3_TRANSITION = 'wpa3_transition'
+CONF_WPA_MODE = 'wpa_mode'
 
 # Some of the below values are duplicates of homeassistant.const values
 # This is done to allow for changes in UniFi API keys
+UNIFI_HIDE_SSID = 'hide_ssid' # duplicate
 UNIFI_ID = '_id'
 UNIFI_NAME = 'name' # duplicate
 UNIFI_NETWORKCONF_ID = 'networkconf_id'
@@ -39,3 +39,5 @@ UNIFI_X_PASSPHRASE = 'x_passphrase'
 UNIFI_X_PASSWORD = 'x_password'
 UNIFI_PASSWORD = 'password' # duplicate
 UNIFI_PRESHARED_KEYS = 'private_preshared_keys'
+UNIFI_WPA3_SUPPORT = 'wpa3_support'
+UNIFI_WPA3_TRANSITION = 'wpa3_transition'

--- a/custom_components/unifi_wifi/services.py
+++ b/custom_components/unifi_wifi/services.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_RANDOM,
     CONF_SSID,
     CONF_WORD_COUNT,
+    UNIFI_HIDE_SSID,
     UNIFI_NAME,
     UNIFI_NETWORKCONF_ID,
     UNIFI_X_PASSPHRASE,
@@ -431,7 +432,7 @@ async def register_services(hass: HomeAssistant, coordinators: List[UnifiWifiCoo
 
         hide_ssid = call.data.get(CONF_HIDE_SSID)
 
-        await _ssid_requests(states, CONF_HIDE_SSID, hide_ssid, True)
+        await _ssid_requests(states, UNIFI_HIDE_SSID, hide_ssid, True)
 
 
     async def hotspot_password_service(call: ServiceCall):


### PR DESCRIPTION
Replace ```wpa3_support``` and ```wpa3_transition``` image attributes with ```wpa_mode```. It is used to decide between ```WPA2```, ```WPA2/WPA3```, and ```WPA3``` based on the now defunct attributes' source keys in wlanconf. This new attribute will be used to determine if an additional flag is needed in the QR code for WPA3 only mode.