### PR TITLE
Remove deprecated List alias in image.py

### DIFF
--- a/custom_components/unifi_wifi/image.py
+++ b/custom_components/unifi_wifi/image.py
@@ -22,7 +22,6 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import parse_datetime, utcnow
 from homeassistant.util import slugify
-from typing import List # required for type hinting (function annotation)
 from .const import (
     DOMAIN,
     CONF_BACK_COLOR,
@@ -61,7 +60,7 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
-    coordinators: List[UnifiWifiCoordinator],
+    coordinators: list[UnifiWifiCoordinator],
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the Unifi Wifi image platform."""


### PR DESCRIPTION
In python 3.9, the use of List as an alias for list was deprecated. Replace with ```utcnow().timestamp()```

https://stackoverflow.com/questions/39458193/using-list-tuple-etc-from-typing-vs-directly-referring-type-as-list-tuple-etc
https://docs.python.org/3/library/typing.html#deprecated-aliases
