### PR TITLE
update cookie separator in coordinator.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ unifi_wifi:
   Change hotspot password on UniFi network to a randomly generated string
   - char --> 24-character alphanumeric string
   - word --> 4-word string, generated from the [EFF large wordlist](https://www.eff.org/files/2016/07/18/eff_large_wordlist.txt) [^2]. This wordfile is located in ```custom_components/unfi_wifi```
-  - xkcd --> 4-word string, generated using [xkcdpass](https://pypi.org/project/xkcdpass). By default, xkcdpass only has access to the same wordfile as ```word```. The benefit of xkcdpass is having control over the length of words chosen.
+  - xkcd --> 4-word string, generated using [xkcdpass](https://pypi.org/project/xkcdpass). By default, ```xkcd``` only has access to the same wordfile as ```word```. The benefit of xkcdpass is having control over the length of words chosen.
 
   ```yaml
     action: unifi_wifi.hotspot_password

--- a/custom_components/unifi_wifi/coordinator.py
+++ b/custom_components/unifi_wifi/coordinator.py
@@ -136,7 +136,7 @@ class UnifiWifiCoordinator(DataUpdateCoordinator):
         response = await self._request(session, 'post', path, **kwargs)
 
         # Create a cookie from the current session response and add it to the headers
-        headers['Cookie'] = ', '.join(response.headers.getall('Set-Cookie'))
+        headers['Cookie'] = '; '.join(response.headers.getall('Set-Cookie'))
         if self._unifi_os:
             headers[UNIFI_CSRF_TOKEN] = response.headers.get(UNIFI_CSRF_TOKEN)
 


### PR DESCRIPTION
Individual ```<Name>=<Value>``` data pairs in the request cookie should be separated with a semicolon instead of a comma.

https://stackoverflow.com/questions/4843556/in-http-specification-what-is-the-string-that-separates-cookies