### PR TITLE
Change initial state attribute defining process

### DIFF
--- a/custom_components/unifi_wifi/const.py
+++ b/custom_components/unifi_wifi/const.py
@@ -30,16 +30,16 @@ CONF_UNIFI_OS = 'unifi_os'
 CONF_WORD_COUNT = 'word_count'
 CONF_WPA_MODE = 'wpa_mode'
 
-# Some of the below values are duplicates of homeassistant.const values
+# Some of the below values are duplicates of CONF or homeassistant.const values
 # This is done to allow for changes in UniFi API keys
-UNIFI_HIDE_SSID = 'hide_ssid' # duplicate
+UNIFI_HIDE_SSID = 'hide_ssid' # duplicate (CONF)
 UNIFI_ID = '_id'
-UNIFI_NAME = 'name' # duplicate
+UNIFI_NAME = 'name' # duplicate (const)
 UNIFI_NETWORKCONF_ID = 'networkconf_id'
 UNIFI_CSRF_TOKEN = 'X-CSRF-Token'
 UNIFI_X_PASSPHRASE = 'x_passphrase'
 UNIFI_X_PASSWORD = 'x_password'
-UNIFI_PASSWORD = 'password' # duplicate
+UNIFI_PASSWORD = 'password' # duplicate (const)
 UNIFI_PRESHARED_KEYS = 'private_preshared_keys'
 UNIFI_WPA3_SUPPORT = 'wpa3_support'
 UNIFI_WPA3_TRANSITION = 'wpa3_transition'


### PR DESCRIPTION
When an image entity is newly created,  some of its attributes are not accurate until an entity update is triggered. This PR changes the order in which attributes are defined so that all attributes are accurate prior to being set in HASS